### PR TITLE
Proxy pass location to GH Pages page.

### DIFF
--- a/kubernetes/releases/voice-prod/voice-prod-chart.yaml
+++ b/kubernetes/releases/voice-prod/voice-prod-chart.yaml
@@ -30,6 +30,12 @@ spec:
         class: voice-prod
         host: voice.mozilla.org
         additional_host: prod.voice.mozit.cloud
+        extra_annotations:
+          nginx.ingress.kubernetes.io/server-snippet: |
+            location /firefox-voice {
+              add_header Content-Security-Policy "default-src 'none'; connect-src https://www.google-analytics.com https://sentry.prod.mozaws.net; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.googleapis.com; script-src 'self' https://www.google-analytics.com; img-src 'self' data:; child-src https://www.youtube.com" ;
+              proxy_pass https://mozilla.github.io/firefox-voice/homepage;
+            }
 
       service_account:
         annotations:

--- a/kubernetes/releases/voice-sandbox/voice-sandbox-chart.yaml
+++ b/kubernetes/releases/voice-sandbox/voice-sandbox-chart.yaml
@@ -29,6 +29,12 @@ spec:
         class: voice-sandbox
         host: sandbox.voice.mozit.cloud
         additional_host: voice-sandbox.allizom.org
+        extra_annotations:
+          nginx.ingress.kubernetes.io/server-snippet: |
+            location /firefox-voice {
+              add_header Content-Security-Policy "default-src 'none'; connect-src https://www.google-analytics.com https://sentry.prod.mozaws.net; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.googleapis.com; script-src 'self' https://www.google-analytics.com; img-src 'self' data:; child-src https://www.youtube.com" ;
+              proxy_pass https://mozilla.github.io/firefox-voice/homepage;
+            }
 
       service_account:
         annotations:

--- a/kubernetes/releases/voice-stage/voice-stage-chart.yaml
+++ b/kubernetes/releases/voice-stage/voice-stage-chart.yaml
@@ -29,6 +29,12 @@ spec:
         class: voice-stage
         host: stage.voice.mozit.cloud
         additional_host: voice.allizom.org
+        extra_annotations:
+          nginx.ingress.kubernetes.io/server-snippet: |
+            location /firefox-voice {
+              add_header Content-Security-Policy "default-src 'none'; connect-src https://www.google-analytics.com https://sentry.prod.mozaws.net; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.googleapis.com; script-src 'self' https://www.google-analytics.com; img-src 'self' data:; child-src https://www.youtube.com" ;
+              proxy_pass https://mozilla.github.io/firefox-voice/homepage;
+            }
 
       service_account:
         annotations:


### PR DESCRIPTION
Firefox Team wants to create a homepage for Firefox Voice at https://voice.mozilla.org/firefox-voice. The site is not yet ready but I have been told it can be ready at any time, and we need to do this soon