### PR TITLE
Deploy Grafana for Voice stats

### DIFF
--- a/kubernetes/namespaces/stats.yaml
+++ b/kubernetes/namespaces/stats.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stats

--- a/kubernetes/releases/stats/grafana.yaml
+++ b/kubernetes/releases/stats/grafana.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: grafana
+  namespace: stats
+spec:
+  chart:
+    repository: https://kubernetes-charts.storage.googleapis.com
+    name: grafana
+    version: 5.0.24
+  values:
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: "stats"
+      hosts:
+        - "stats.voice.mozit.cloud"
+    persistence:
+      enabled: true
+      size: 10Gi
+    grafana.ini:
+      domain: stats.voice.mozit.cloud

--- a/kubernetes/releases/stats/ingress-controller.yaml
+++ b/kubernetes/releases/stats/ingress-controller.yaml
@@ -1,0 +1,41 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: ingress-controller
+  namespace: stats
+spec:
+  chart:
+    repository: https://kubernetes-charts.storage.googleapis.com
+    name: nginx-ingress
+    version: 1.31.0
+  values:
+    controller:
+      name: ingress-stats
+      ingressClass: stats # Value used for selecting Ingress objects
+      scope:
+        enabled: true
+        namespace: stats
+      kind: Deployment
+      autoscalig: 
+        enabled: false
+      replicaCount: 1
+      addHeaders:
+        X-Frame-Options: "DENY"
+        X-Content-Type-Options: "nosniff"
+        X-XSS-Protection: "1; mode=block"
+        Strict-Transport-Security: "max-age=31536000"
+
+      service:
+        targetPorts:
+          https: http
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+          service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
+          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:058419420086:certificate/07ec3379-0729-4b0e-9a9d-b27d179b0b4d
+          service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-TLS-1-2-2017-01
+      config:
+        use-forwarded-headers: "true"
+        ssl-redirect: "true"
+        force-ssl-redirect: "true"
+    defaultBackend:
+      enabled: false

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -69,3 +69,17 @@ resource "aws_acm_certificate" "prod" {
     create_before_destroy = true
   }
 }
+
+resource "aws_acm_certificate" "stats" {
+  domain_name = "stats.voice.mozit.cloud"
+
+  tags = {
+    Name = "stats-voice"
+  }
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}


### PR DESCRIPTION
Voice team is consolidating their metrics/stats systems. After testing if Grafana could replace their current SaaS product for stats, they are happy with the result.
Hopefully this will allow us to get rid of the ugly ES/Kibana instance.