### PR TITLE
Prepare DNS and SSL certs for renaming voice to commonvoice

### DIFF
--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -70,6 +70,87 @@ resource "aws_acm_certificate" "prod" {
   }
 }
 
+resource "aws_acm_certificate" "dev_ssl_cert" {
+  domain_name = "voice-dev.allizom.org"
+
+  subject_alternative_names = [
+    "dev.voice.mozit.cloud",
+    "commonvoice-dev.allizom.org",
+    "dev.commonvoice.mozit.cloud",
+  ]
+
+  validation_method = "DNS"
+
+  tags = {
+    Name = "voice-k8s-dev"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "sandbox_ssl_cert" {
+  domain_name = "voice-sandbox.allizom.org"
+
+  subject_alternative_names = [
+    "sandbox.voice.mozit.cloud",
+    "dev.commonvoice.mozit.cloud",
+    "commonvoice-sandbox.allizom.org",
+    "sandbox.commonvoice.mozit.cloud",
+  ]
+
+  tags = {
+    Name = "voice-k8s-sandbox"
+  }
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "stage_ssl_cert" {
+  domain_name = "voice.allizom.org"
+
+  subject_alternative_names = [
+    "stage.voice.mozit.cloud",
+    "commonvoice.allizom.org",
+    "stage.commonvoice.mozit.cloud",
+  ]
+
+  tags = {
+    Name = "voice-k8s-stage"
+  }
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_acm_certificate" "prod_ssl_cert" {
+  domain_name = "voice.mozilla.org"
+
+  subject_alternative_names = [
+    "prod.voice.mozit.cloud",
+    "commonvoice.mozilla.org",
+    "prod.commonvoice.mozit.cloud",
+  ]
+
+  tags = {
+    Name = "voice-k8s-prod"
+  }
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_acm_certificate" "stats" {
   domain_name = "stats.voice.mozit.cloud"
 

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -81,3 +81,55 @@ resource "aws_route53_record" "stats" {
     evaluate_target_health = false
   }
 }
+
+resource "aws_route53_zone" "commonvoice_mozit_cloud" {
+  name = "commonvoice.mozit.cloud"
+}
+
+resource "aws_route53_record" "dev_commonvoice_mozit_cloud" {
+  zone_id = aws_route53_zone.commonvoice_mozit_cloud.zone_id
+  name    = "dev.commonvoice.mozit.cloud"
+  type    = "A"
+
+  alias {
+    name                   = data.aws_elb.dev.dns_name
+    zone_id                = data.aws_elb.dev.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "sandbox_commonvoice_mozit_cloud" {
+  zone_id = aws_route53_zone.commonvoice_mozit_cloud.zone_id
+  name    = "sandbox.commonvoice.mozit.cloud"
+  type    = "A"
+
+  alias {
+    name                   = data.aws_elb.sandbox.dns_name
+    zone_id                = data.aws_elb.sandbox.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "stage_commonvoice_mozit_cloud" {
+  zone_id = aws_route53_zone.commonvoice_mozit_cloud.zone_id
+  name    = "stage.commonvoice.mozit.cloud"
+  type    = "A"
+
+  alias {
+    name                   = data.aws_elb.stage.dns_name
+    zone_id                = data.aws_elb.stage.zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_route53_record" "prod_commonvoice_mozit_cloud" {
+  zone_id = aws_route53_zone.commonvoice_mozit_cloud.zone_id
+  name    = "prod.commonvoice.mozit.cloud"
+  type    = "A"
+
+  alias {
+    name                   = data.aws_elb.prod.dns_name
+    zone_id                = data.aws_elb.prod.zone_id
+    evaluate_target_health = false
+  }
+}


### PR DESCRIPTION
This change is to prepare for serving commonvoice (currently voice.mozilla.org in production) in commonvoice.mozilla.org. Other addresses apply to other environments.
For this, I'm creating a new Route53 zone "commonvoice.mozit.cloud" (Infoblox is already delegating queries there) and associated SSL certs to match the names that developers asked for.
```
The primary domain of Common Voice will be commonvoice.mozilla.org
Secondary domains will follow the same naming pattern as before, i.e.:
    Stage: commonvoice.allizom.org
    Dev: commonvoice-dev.allizom.org
    Sandbox: commonvoice-sandbox.allizom.org
```

The reason for duplicating the SSL certificates instead of modifying current ones is that, adding new names means recreating the certificate. Based on my experience, getting the certificates verified can take minutes if no hours in some cases. And that would mean downtime for our users.
Once the certificates are created and verified, I'll proceed with attaching them to the ELBs and later, deleting the old ones