### PR TITLE
Simplify dns

### DIFF
--- a/kubernetes/releases/voice-dev/ingress-controller.yaml
+++ b/kubernetes/releases/voice-dev/ingress-controller.yaml
@@ -29,7 +29,7 @@ spec:
         annotations:
           service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
           service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:058419420086:certificate/a1eae049-6d83-4020-989b-6e9c48a34bee
+          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:058419420086:certificate/b54042bc-500a-4881-9f65-ebdf78362e77
           service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-TLS-1-1-2017-01
       config:
         use-forwarded-headers: "true"

--- a/terraform/acm.tf
+++ b/terraform/acm.tf
@@ -70,87 +70,6 @@ resource "aws_acm_certificate" "prod" {
   }
 }
 
-resource "aws_acm_certificate" "dev_ssl_cert" {
-  domain_name = "voice-dev.allizom.org"
-
-  subject_alternative_names = [
-    "commonvoice-dev.allizom.org",
-    "dev.commonvoice.mozit.cloud",
-    "dev.voice.mozit.cloud",
-  ]
-
-  validation_method = "DNS"
-
-  tags = {
-    Name = "voice-k8s-dev"
-  }
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_acm_certificate" "sandbox_ssl_cert" {
-  domain_name = "voice-sandbox.allizom.org"
-
-  subject_alternative_names = [
-    "sandbox.voice.mozit.cloud",
-    "dev.commonvoice.mozit.cloud",
-    "sandbox.commonvoice.mozit.cloud",
-    "commonvoice-sandbox.allizom.org",
-  ]
-
-  tags = {
-    Name = "voice-k8s-sandbox"
-  }
-
-  validation_method = "DNS"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_acm_certificate" "stage_ssl_cert" {
-  domain_name = "voice.allizom.org"
-
-  subject_alternative_names = [
-    "stage.commonvoice.mozit.cloud",
-    "stage.voice.mozit.cloud",
-    "commonvoice.allizom.org",
-  ]
-
-  tags = {
-    Name = "voice-k8s-stage"
-  }
-
-  validation_method = "DNS"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_acm_certificate" "prod_ssl_cert" {
-  domain_name = "voice.mozilla.org"
-
-  subject_alternative_names = [
-    "prod.commonvoice.mozit.cloud",
-    "commonvoice.mozilla.org",
-    "prod.voice.mozit.cloud",
-  ]
-
-  tags = {
-    Name = "voice-k8s-prod"
-  }
-
-  validation_method = "DNS"
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_acm_certificate" "stats" {
   domain_name = "stats.voice.mozit.cloud"
 
@@ -163,4 +82,123 @@ resource "aws_acm_certificate" "stats" {
   lifecycle {
     create_before_destroy = true
   }
+}
+
+#
+# Common Voice SSL Certificates and validations
+#
+
+# Dev
+
+resource "aws_acm_certificate" "dev_ssl_cert" {
+  domain_name = "dev.commonvoice.allizom.org"
+
+  subject_alternative_names = [
+    "dev.voice.mozit.cloud",
+    "voice-dev.allizom.org",
+  ]
+
+  validation_method = "DNS"
+
+  tags = {
+    Name = "commonvoice-dev"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "dev_validation" {
+  name    = aws_acm_certificate.dev_ssl_cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.dev_ssl_cert.domain_validation_options.0.resource_record_type
+  zone_id = aws_route53_zone.commonvoice_allizom_org.zone_id
+  records = [aws_acm_certificate.dev_ssl_cert.domain_validation_options.0.resource_record_value]
+  ttl     = 60
+}
+
+# Sandbox
+
+resource "aws_acm_certificate" "sandbox_ssl_cert" {
+  domain_name = "sandbox.commonvoice.allizom.org"
+
+  subject_alternative_names = [
+    "sandbox.voice.mozit.cloud",
+    "voice-sandbox.allizom.org",
+  ]
+
+  tags = {
+    Name = "commonvoice-sandbox"
+  }
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "sandbox_validation" {
+  name    = aws_acm_certificate.sandbox_ssl_cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.sandbox_ssl_cert.domain_validation_options.0.resource_record_type
+  zone_id = aws_route53_zone.commonvoice_allizom_org.zone_id
+  records = [aws_acm_certificate.sandbox_ssl_cert.domain_validation_options.0.resource_record_value]
+  ttl     = 60
+}
+
+# Stage
+
+resource "aws_acm_certificate" "stage_ssl_cert" {
+  domain_name = "commonvoice.allizom.org"
+
+  subject_alternative_names = [
+    "voice.allizom.org",
+    "stage.voice.mozit.cloud",
+  ]
+
+  tags = {
+    Name = "commonvoice-stage"
+  }
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "stage_validation" {
+  name    = aws_acm_certificate.stage_ssl_cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.stage_ssl_cert.domain_validation_options.0.resource_record_type
+  zone_id = aws_route53_zone.commonvoice_allizom_org.zone_id
+  records = [aws_acm_certificate.stage_ssl_cert.domain_validation_options.0.resource_record_value]
+  ttl     = 60
+}
+
+# Prod
+resource "aws_acm_certificate" "prod_ssl_cert" {
+  domain_name = "commonvoice.mozilla.org"
+
+  subject_alternative_names = [
+    "prod.voice.mozit.cloud",
+    "voice.mozilla.org",
+  ]
+
+  tags = {
+    Name = "commonvoice-prod"
+  }
+
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "prod_validation" {
+  name    = aws_acm_certificate.prod_ssl_cert.domain_validation_options.0.resource_record_name
+  type    = aws_acm_certificate.prod_ssl_cert.domain_validation_options.0.resource_record_type
+  zone_id = aws_route53_zone.commonvoice_mozilla_org.zone_id
+  records = [aws_acm_certificate.prod_ssl_cert.domain_validation_options.0.resource_record_value]
+  ttl     = 60
 }

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -86,13 +86,19 @@ resource "aws_route53_record" "stats" {
 ####################
 #   Common Voice   #
 ####################
-resource "aws_route53_zone" "commonvoice_mozit_cloud" {
-  name = "commonvoice.mozit.cloud"
+
+resource "aws_route53_zone" "commonvoice_allizom_org" {
+  name = "commonvoice.allizom.org"
 }
 
-resource "aws_route53_record" "dev_commonvoice_mozit_cloud" {
-  zone_id = aws_route53_zone.commonvoice_mozit_cloud.zone_id
-  name    = "dev.commonvoice.mozit.cloud"
+resource "aws_route53_zone" "commonvoice_mozilla_org" {
+  name = "commonvoice.mozilla.org"
+}
+
+# Dev record
+resource "aws_route53_record" "dev_commonvoice_allizom_org" {
+  zone_id = aws_route53_zone.commonvoice_allizom_org.zone_id
+  name    = "dev.commonvoice.allizom.org"
   type    = "A"
 
   alias {
@@ -102,9 +108,10 @@ resource "aws_route53_record" "dev_commonvoice_mozit_cloud" {
   }
 }
 
-resource "aws_route53_record" "sandbox_commonvoice_mozit_cloud" {
-  zone_id = aws_route53_zone.commonvoice_mozit_cloud.zone_id
-  name    = "sandbox.commonvoice.mozit.cloud"
+# Sandbox record
+resource "aws_route53_record" "sandbox_commonvoice_allizom_org" {
+  zone_id = aws_route53_zone.commonvoice_allizom_org.zone_id
+  name    = "sandbox.commonvoice.allizom.org"
   type    = "A"
 
   alias {
@@ -114,9 +121,10 @@ resource "aws_route53_record" "sandbox_commonvoice_mozit_cloud" {
   }
 }
 
-resource "aws_route53_record" "stage_commonvoice_mozit_cloud" {
-  zone_id = aws_route53_zone.commonvoice_mozit_cloud.zone_id
-  name    = "stage.commonvoice.mozit.cloud"
+# Stage record
+resource "aws_route53_record" "stage_commonvoice_allizom_org" {
+  zone_id = aws_route53_zone.commonvoice_allizom_org.zone_id
+  name    = "commonvoice.allizom.org"
   type    = "A"
 
   alias {
@@ -124,24 +132,4 @@ resource "aws_route53_record" "stage_commonvoice_mozit_cloud" {
     zone_id                = data.aws_elb.stage.zone_id
     evaluate_target_health = false
   }
-}
-
-resource "aws_route53_record" "prod_commonvoice_mozit_cloud" {
-  zone_id = aws_route53_zone.commonvoice_mozit_cloud.zone_id
-  name    = "prod.commonvoice.mozit.cloud"
-  type    = "A"
-
-  alias {
-    name                   = data.aws_elb.prod.dns_name
-    zone_id                = data.aws_elb.prod.zone_id
-    evaluate_target_health = false
-  }
-}
-
-resource "aws_route53_zone" "commonvoice_allizom_org" {
-  name = "commonvoice.allizom.org"
-}
-
-resource "aws_route53_zone" "commonvoice_mozilla_org" {
-  name = "commonvoice.mozilla.org"
 }


### PR DESCRIPTION
This PR simplifies DNS management moving away from the non-production domains `<env>-comonvoice.allizom.org` to `<env>.commonvoice.allizom.org`. This allow us to have 1 subzone for prod and 1 subzone for non-prod environments.

For this it creates 2 DNS subzones: commonvoice.mozilla.org and commonvoice.allizom.org. This zones are already Delegated from Infoblox to here.
It also adjustes the SSL certs to reflect the new domain names.

Lately, it applies the new certificate to the dev environment. Will move to other environments once we verify it works as expected
