### PR TITLE
Voice Prod: listen also in commonvoice.mozilla.org

### DIFF
--- a/kubernetes/releases/voice-prod/ingress-controller.yaml
+++ b/kubernetes/releases/voice-prod/ingress-controller.yaml
@@ -29,7 +29,7 @@ spec:
         annotations:
           service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
           service.beta.kubernetes.io/aws-load-balancer-ssl-ports: https
-          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:058419420086:certificate/2cdc08da-56f7-4750-8a2a-2d3218d9e9f0
+          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: arn:aws:acm:us-west-2:058419420086:certificate/38a57526-930b-4b83-abbb-c582acc4c630
           service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: ELBSecurityPolicy-TLS-1-1-2017-01
       config:
         use-forwarded-headers: "true"

--- a/kubernetes/releases/voice-prod/voice-prod-chart.yaml
+++ b/kubernetes/releases/voice-prod/voice-prod-chart.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: mozilla-common-voice
-    version: 0.2.2
+    version: 0.3.0
   values:
     voice_web:
       # Customize deployment name per environment to make hostnames differents,
@@ -28,8 +28,10 @@ spec:
       ingress:
         enabled: true
         class: voice-prod
-        host: voice.mozilla.org
-        additional_host: prod.voice.mozit.cloud
+        hosts:
+          - voice.mozilla.org
+          - prod.voice.mozit.cloud
+          - commonvoice.mozilla.org
         extra_annotations:
           nginx.ingress.kubernetes.io/server-snippet: |
             location /firefox-voice {


### PR DESCRIPTION
This PR will allow to serve Common Voice from commonvoice.mozilla.org. It adds the URL to the allowed hosts and uses a new SSL certificate which incorpores the new name
```
aws acm describe-certificate --certificate-arn arn:aws:acm:us-west-2:058419420086:certificate/38a57526-930b-4b83-abbb-c582acc4c630 --output text --query 'Certificate.[DomainName,SubjectAlternativeNames]'
commonvoice.mozilla.org                                                                                                          
commonvoice.mozilla.org	prod.voice.mozit.cloud	voice.mozilla.org
```