### PR TITLE
Point Flux to new docker repository

### DIFF
--- a/kubernetes/releases/voice-dev/voice-dev-chart.yaml
+++ b/kubernetes/releases/voice-dev/voice-dev-chart.yaml
@@ -22,7 +22,7 @@ spec:
       replicas: 3
       use_external_secrets: true
       use_default_secrets_file: false
-      image: itsre/voice-web:main-810092b3070f3919bb49fa95d8e2aef850c87b3a
+      image: mozilla/commonvoice:main-810092b3070f3919bb49fa95d8e2aef850c87b3a
       service_account_name: voice-dev
       extra_annotations:
         configmap.reloader.stakater.com/reload: "voice-config"

--- a/kubernetes/releases/voice-sandbox/voice-sandbox-chart.yaml
+++ b/kubernetes/releases/voice-sandbox/voice-sandbox-chart.yaml
@@ -20,7 +20,7 @@ spec:
       deployment_name: voice-sandbox
       use_external_secrets: true
       use_default_secrets_file: false
-      image: itsre/voice-web:sandbox-demo-v0.1
+      image: mozilla/commonvoice:sandbox-demo-v0.1
       replicas: 1
       service_account_name: voice-sandbox
       extra_annotations:

--- a/kubernetes/releases/voice-stage/voice-stage-chart.yaml
+++ b/kubernetes/releases/voice-stage/voice-stage-chart.yaml
@@ -21,7 +21,7 @@ spec:
       deployment_name: voice-stage
       use_external_secrets: true
       use_default_secrets_file: false
-      image: itsre/voice-web:stage-95b5c1971a1d6c848f218b44f155b0d9373458f2
+      image: mozilla/commonvoice:stage-95b5c1971a1d6c848f218b44f155b0d9373458f2
       replicas: 3
       service_account_name: voice-stage
       extra_annotations:


### PR DESCRIPTION
This PR is a follow up from https://github.com/mozilla/common-voice/pull/2862
Travis is storing the artifacts built into a different Docker repository under Mozilla Organisation, so this will point Flux there.

I've manually mirrored the referenced images.
@phirework note that I didn't modify production. With the next release, remember to point it to the new registry. (If you forget, nothing bad won't happen, just k8s won't be able to pull the referenced image, so it won't kill the production pods)