### PR TITLE
Allow unauthenticated view access

### DIFF
--- a/kubernetes/releases/stats/grafana.yaml
+++ b/kubernetes/releases/stats/grafana.yaml
@@ -23,8 +23,12 @@ spec:
         domain: stats.voice.mozit.cloud
         root_url: https://stats.voice.mozit.cloud
       auth:
-        disable_login_form: true
-        oauth_auto_login: true
+        disable_login_form: false
+        oauth_auto_login: false
+      auth.anonymous:
+        enabled: true
+        org_name: Mozilla Common Voice
+        org_role: Viewer
       auth.basic:
         enabled: false
     envFromSecret: grafana-auth0-secrets

--- a/kubernetes/releases/stats/grafana.yaml
+++ b/kubernetes/releases/stats/grafana.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     repository: https://kubernetes-charts.storage.googleapis.com
     name: grafana
-    version: 5.1.4
+    version: 5.5.5
   values:
     ingress:
       enabled: true


### PR DESCRIPTION
This PR will allow unauthenticated users, Viewer rights. With those rights, unauthenticated users can see a set of allowed Dashboards.
It also bumps the Chart version to latest: some small fixes and using latest Grafana app version 7.1.1