### PR TITLE
Serve Mozilla Dev Tools site on voice.m.o

### DIFF
--- a/kubernetes/releases/voice-prod/domain-redirection.yaml
+++ b/kubernetes/releases/voice-prod/domain-redirection.yaml
@@ -16,6 +16,15 @@ metadata:
         add_header Content-Security-Policy "default-src 'none'; connect-src https://www.google-analytics.com https://sentry.prod.mozaws.net; style-src 'self' https://fonts.googleapis.com; font-src 'self' https://fonts.googleapis.com; script-src 'self' https://www.google-analytics.com; img-src 'self' data:; child-src https://www.youtube.com" ;
         proxy_pass https://mozilla-extensions.github.io/firefox-voice/homepage;
       }
+      # Serving Mozilla Voice website when visiting /
+      # and falling back to CommonVoice to maintain compatibility
+      # with links spreaded in the web
+      location ~ ^(/$|/about|/news|/partners|/community|/voice-devtools-) {
+        if ($http_x_forwarded_proto = 'http') {
+          rewrite ^ https://$host$request_uri? permanent;
+        }
+        proxy_pass https://voice-dev-tools.netlify.app;
+      }
 spec:
   rules:
   - host: voice.mozilla.org


### PR DESCRIPTION
Keeping links spread across the web reaching CommonVoice usin the NGINX catch path