### PR TITLE
Reflect cluster upgrade to 1.16

### DIFF
--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -1,6 +1,6 @@
 locals {
   cluster_name    = "voice-prod"
-  cluster_version = "1.15"
+  cluster_version = "1.16"
 
   cluster_tags = {
     Region    = var.region


### PR DESCRIPTION
This PR reflects the upgrade of the cluster to EKS 1.16.
As part of the upgrade, we modified:
 - api server
 - kube-proxy
 - aws cni plugin

Left behind to upgrade is cluster-autoscaler because there isn't a helm chart suiting version 1.16. With the next upgrade to 1.17, cluster-autoscaler will be upgraded