### PR TITLE
redis-cli --tls support in db-monitor image & deployments

### DIFF
--- a/dockerfiles/db-monitor/Dockerfile
+++ b/dockerfiles/db-monitor/Dockerfile
@@ -1,9 +1,19 @@
 FROM ubuntu:focal
 
-MAINTAINER "Alberto del Barrio <alberto@mozilla.com>"
+RUN apt-get update \
+    && apt-get install -y \
+        build-essential \
+        libssl-dev \
+        mysql-client \
+        wget \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
-
-RUN apt-get update && \
-    apt-get install -y mysql-client redis-tools stunnel4
+RUN wget http://download.redis.io/redis-stable.tar.gz \
+    && tar xvzf redis-stable.tar.gz \
+    && cd redis-stable \
+    && make BUILD_TLS=yes \
+    && cp src/redis-cli /usr/local/bin/ \
+    && chmod +x /usr/local/bin/redis-cli
 
 RUN echo 'alias mysql="mysql --host $CV_MYSQLHOST --user $CV_MYSQLUSER --database voice -p$CV_MYSQL_PASS"' >> /root/.bashrc

--- a/dockerfiles/db-monitor/Dockerfile
+++ b/dockerfiles/db-monitor/Dockerfile
@@ -14,6 +14,8 @@ RUN wget http://download.redis.io/redis-stable.tar.gz \
     && cd redis-stable \
     && make BUILD_TLS=yes \
     && cp src/redis-cli /usr/local/bin/ \
-    && chmod +x /usr/local/bin/redis-cli
+    && chmod +x /usr/local/bin/redis-cli \
+    && cd .. \
+    && rm -rf redis-stable redis-stable.tar.gz
 
 RUN echo 'alias mysql="mysql --host $CV_MYSQLHOST --user $CV_MYSQLUSER --database voice -p$CV_MYSQL_PASS"' >> /root/.bashrc

--- a/kubernetes/releases/voice-prod/db-monitor.yaml
+++ b/kubernetes/releases/voice-prod/db-monitor.yaml
@@ -13,7 +13,6 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  annotations:
   labels:
     app: db-monitor
   name: db-monitor
@@ -34,7 +33,7 @@ spec:
         - while true; do echo hello; sleep 100;done
         command:
         - /bin/sh
-        image: 058419420086.dkr.ecr.us-west-2.amazonaws.com/db-monitor:0.0.2
+        image: 058419420086.dkr.ecr.us-west-2.amazonaws.com/db-monitor:0.0.3
         imagePullPolicy: Always
         name: aws-cli
         resources:

--- a/kubernetes/releases/voice-stage/db-monitor.yaml
+++ b/kubernetes/releases/voice-stage/db-monitor.yaml
@@ -13,7 +13,6 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  annotations:
   labels:
     app: db-monitor
   name: db-monitor
@@ -34,7 +33,7 @@ spec:
         - while true; do echo hello; sleep 100;done
         command:
         - /bin/sh
-        image: 058419420086.dkr.ecr.us-west-2.amazonaws.com/db-monitor:0.0.2
+        image: 058419420086.dkr.ecr.us-west-2.amazonaws.com/db-monitor:0.0.3
         imagePullPolicy: Always
         name: aws-cli
         resources:


### PR DESCRIPTION
Jira ticket: https://jira.mozilla.com/browse/SE-1841

What this PR does:
* builds latest stable redis-cli on db-monitor docker image in order to support redis-cli --tls with no other configurations
* removes old install (ubuntu packages redis-tools & stunnel4 for tls tunnel for redis)

Why:
* redis-cli cannot connect to our AWS elasticache redis instances without supporting tls. stunnel4 is able to create tls tunnel for redis-cli, but looks like it was never setup.
* out of TLS with redis-cli options (install latest redis-cli with tls support - which we have to build ourselves, use redli - a work-around of the redis-cli that has tls support baked in, or fully setup stunnel4 with environment-specific endpoint configurations for TLS connections), installing the latest redis-cli with full tls support by building it on the container seemed th ebest route.

Next steps:
* pretty sure there is no automated CI for the db-monitor image or deployment, so will build, push, and kubectl apply after approval & merge
* have @phirework confirm everything still works as expected on updated deploys