### PR TITLE
2 minor updates for db-monitor deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,24 @@ In order to connect to the database server, run:
 
 Once you are inside the pod, just run `mysql` to connect to the database server.
 
+The db-monitor pod is manually managed. In order to update & deploy the DB monitor pod, there are two possible steps:
+
+1. Update, build, and push the Docker Image (058419420086.dkr.ecr.us-west-2.amazonaws.com/db-monitor). 
+
+```
+maws  # log into AWS account appsvcs-voice via MAWS or however you prefer, as maws-commonvoice-admin
+aws ecr get-login-password | docker login --username AWS --password-stdin 058419420086.dkr.ecr.us-west-2.amazonaws.com
+docker build -t 058419420086.dkr.ecr.us-west-2.amazonaws.com/db-monitor:0.0.3 dockerfiles/db-monitor/  # uptick tagged version as relevant, will require update in k8s manifest mentioned below
+docker push 058419420086.dkr.ecr.us-west-2.amazonaws.com/db-monitor:0.0.3
+```
+
+2. Redeploy the db-monitor deployment:
+```
+vi kubernetes/releases/voice-stage/db-monitor.yaml  # change anything that might need changing, like docker image for stage environment
+vi kubernetes/releases/voice-prod/db-monitor.yaml  # ditto for prod environment
+kubectl apply -f kubernetes/releases/voice-stage/db-monitor.yaml
+kubectl apply -f kubernetes/releases/voice-prod/db-monitor.yaml
+```
 
 # Sentence Collector
 [Sentence Collector](https://github.com/Common-Voice/sentence-collector) is an application used to collect sentences from users, which will be later used in Common Voice.

--- a/kubernetes/releases/voice-prod/db-monitor.yaml
+++ b/kubernetes/releases/voice-prod/db-monitor.yaml
@@ -10,7 +10,7 @@ spec:
       property: CV_DB_ROOT_PASS
       name: CV_MYSQL_PASS
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kubernetes/releases/voice-stage/db-monitor.yaml
+++ b/kubernetes/releases/voice-stage/db-monitor.yaml
@@ -10,7 +10,7 @@ spec:
       property: CV_DB_ROOT_PASS
       name: CV_MYSQL_PASS
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Jira Ticket: https://jira.mozilla.com/browse/SE-1841

Alright, confirming there's no automation on db-monitor, I added two things here:

1. the db-monitor deployments needed to update their API to get around some kubernetes API deprecations. Doesn't change anything about the deployment otherwise.
2. added a few lines to README.md about how to manually update anything dealing with the db-monitor resources. These steps are probably already known, but it marks for future reference that db-monitor is definitely manually managed.

Everything in this PR has been applied already to stage and prod, so is also ready for further testing & review. This should've been in #142 , so I apologize for the oversight.