### PR TITLE
for voice-dev, use voice-dockerhub as imagePullSecrets

### DIFF
--- a/kubernetes/releases/voice-dev/voice-dev-chart.yaml
+++ b/kubernetes/releases/voice-dev/voice-dev-chart.yaml
@@ -13,7 +13,7 @@ spec:
   chart:
     repository: https://mozilla-it.github.io/helm-charts/
     name: mozilla-common-voice
-    version: 0.4.1
+    version: 0.4.5
   values:
     voice_web:
       # Customize deployment name per environment to make hostnames differents,
@@ -27,6 +27,8 @@ spec:
       extra_annotations:
         configmap.reloader.stakater.com/reload: "voice-config"
         secret.reloader.stakater.com/reload: "voice"
+      imagePullSecrets:
+        - name: voice-dockerhub
 
       ingress:
         enabled: true


### PR DESCRIPTION
Jira Ticket: https://mozilla-hub.atlassian.net/browse/SE-2416

What this PR does:
* adds imagePullSecrets to voice-dev deploy, in order to test dockerhub rate-limiting theory as source of deploy bug
* updates helmrelease for voice-dev to use latest voice helm chart