### PR TITLE
for voice-dev, remove voice-dockerhub as imagePullSecrets

### DIFF
--- a/kubernetes/releases/voice-dev/voice-dev-chart.yaml
+++ b/kubernetes/releases/voice-dev/voice-dev-chart.yaml
@@ -27,8 +27,6 @@ spec:
       extra_annotations:
         configmap.reloader.stakater.com/reload: "voice-config"
         secret.reloader.stakater.com/reload: "voice"
-      imagePullSecrets:
-      - name: voice-dockerhub
 
       ingress:
         enabled: true

--- a/kubernetes/releases/voice-prod/sentence-collector.yaml
+++ b/kubernetes/releases/voice-prod/sentence-collector.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: voice-prod
   annotations:
     fluxcd.io/automated: "true"
-    filter.fluxcd.io/chart-image: glob:v*
+    filter.fluxcd.io/chart-image: regex:^(v[0-9]+.[0-9]+.[0-9]+)$
 spec:
   releaseName: sentence-collector-prod
   chart:


### PR DESCRIPTION
Jira ticket: https://mozilla-hub.atlassian.net/browse/SE-2416

What this PR does:
* Removes imagePullSecret from voice-dev deployment, testing a cluster-wide docker credential instead
* uses regex for v1.2.3 to watch for sentence-collector docker image tag (instead of glob:v{anything}).