### PR TITLE
Fix Grafana Helm repo URL.

### DIFF
--- a/kubernetes/releases/stats/grafana.yaml
+++ b/kubernetes/releases/stats/grafana.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: stats
 spec:
   chart:
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://grafana.github.io/helm-charts
     name: grafana
     version: 6.11.0
   values:


### PR DESCRIPTION
Looks like the repo URL has changed. The old URL does not work anymore. The new one is documented here: https://github.com/grafana/helm-charts#usage