### PR TITLE
remove name key from voice-dev helmrelease values

### DIFF
--- a/kubernetes/releases/voice-dev/ingress-controller.yaml
+++ b/kubernetes/releases/voice-dev/ingress-controller.yaml
@@ -22,7 +22,6 @@ spec:
         enable-underscores-in-headers: "true"
       ingressClass: voice-dev # Value used for selecting Ingress objects
       kind: Deployment
-      name: ingress-voice-dev
       replicaCount: 1
       scope:
         enabled: true


### PR DESCRIPTION
See #151 

Handles helm release error mentioned below

```
11              Tue Oct 26 18:24:28 2021        failed          ingress-nginx-3.33.0    0.47.0          Upgrade "voice-dev-ingress-controller" failed: failed to create resource: Service "voice-dev-ingress-controller-ingress-nginx-ingress-voice-dev-admission" is invalid: metadata.name: Invalid value: "voice-dev-ingress-controller-ingress-nginx-ingress-voice-dev-admission": must be no more than 63 characters
```